### PR TITLE
fix: audit and common fixes

### DIFF
--- a/.github/workflows/differential.yaml
+++ b/.github/workflows/differential.yaml
@@ -1,23 +1,23 @@
-name: Bindings
+name: Differential Tests
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  bindings-generation:
-    name: ts
+  differential-tests:
+    name: differential
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout pinned mfkdf2.rs commit
+        uses: actions/checkout@v4
+        with:
+          ref: 7c33c7164d6e40a26c0899f19b8f9ad9b9f0c029
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -28,7 +28,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: typescript/bindings
+          key: typescript/differential
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,9 +56,9 @@ jobs:
         working-directory: mfkdf2-web
         run: npm ci
 
-      - name: Generate TypeScript bindings
+      - name: Generate TypeScript bindings for differential tests
         working-directory: mfkdf2-web
-        run: npm run ubrn:web:release
+        run: npm run ubrn:web:differential:release
 
       - name: Copy index.web.ts implementation
         run: cp mfkdf2-web/src/index.ts mfkdf2-web/src/index.web.ts
@@ -75,25 +75,8 @@ jobs:
           fi
           echo "✓ TypeScript bindings verified"
 
-      - name: Run TypeScript tests with reports
+      - name: Run differential tests
         working-directory: mfkdf2-web
-        run: npm run test:report
+        run: npm run test:differential
 
-      - name: Publish JUnit test report
-        if: always()
-        uses: mikepenz/action-junit-report@v4
-        with:
-          report_paths: "mfkdf2-web/test-results/junit/junit.xml"
-          detailed_summary: true
-          include_passed: true
 
-      - name: Upload HTML test report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mfkdf2-web-mochawesome-report
-          path: mfkdf2-web/test-results/mochawesome/
-
-      - name: Run TypeScript type checking
-        working-directory: mfkdf2-web
-        run: npm run typecheck

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -187,7 +187,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run cargo-llvm-cov
-        run: cargo llvm-cov --all-features --workspace --html --output-dir target/coverage
+        run: cargo llvm-cov --workspace --html --output-dir target/coverage
 
       - name: Upload coverage to Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -119,6 +119,9 @@ jobs:
 
       - name: Run tests (JUnit)
         run: cargo nextest run --release --profile ci
+      
+      - name: Run doctests
+        run: cargo test --release --doc
 
       - name: Publish JUnit test report
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -964,6 +974,7 @@ dependencies = [
  "aes",
  "argon2",
  "base64",
+ "cbc",
  "cipher",
  "console_log",
  "criterion",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,7 @@ Please check here before filing new reports.
 | Affected Version(s) | Description                                                            | Status       | CVE / Advisory |
 | ------------------- | ---------------------------------------------------------------------- | ------------ | -------------- |
 | 0.0.1               | RSA Marvin Attack: potential key recovery through timing sidechannels. | 🔴 Unresolved | 2023-49092     |
+| 0.0.1               | Generic-Array: v0.14.9 is deprecated but used by aes-v0.8.4            | 🔴 Unresolved | -              |
 
 Legend:
 - 🟢 Fixed

--- a/docs/src/differential-tests.md
+++ b/docs/src/differential-tests.md
@@ -31,19 +31,26 @@ See: [multifactor/MFKDF#27](https://github.com/multifactor/MFKDF/pull/27)
 See: [multifactor/MFKDF2.rs#43](https://github.com/multifactor/MFKDF2.rs/pull/43)
 - Add a `differential-test` feature flag providing a global deterministic RNG equivalent to the reference.
 - Provide utility methods in the TypeScript bindings facade for nested parameter parsing and stringification (read/write inner params) to match reference structures.
+- Pin the versions used for differential testing to:
+  - `MFKDF2.rs` commit `7c33c7164d6e40a26c0899f19b8f9ad9b9f0c029`
+  - `MFKDF` commit `3d5bf73b4ce42b23da113b4be6d35e7d941fadf8`
 
 ## How to reproduce
 
-Run the differential tests using the bindings workflow. From the repository root:
+You can run the differential tests **locally** or via the **GitHub Actions workflow**.
+
+### Locally
+
+From the repository root:
 
 ```bash
 # Ensure the WASM target is present (one-time)
 rustup target add wasm32-unknown-unknown
 
-# Generate differential-release bindings (optimized)
+# Generate differential-release bindings (includes the `differential-test` feature)
 just gen-ts-bindings-differential
 
-# Run the TypeScript test suite (includes differential tests)
+# Run only the differential TypeScript test suite
 just test-bindings-differential
 ```
 

--- a/mfkdf2-web/package-lock.json
+++ b/mfkdf2-web/package-lock.json
@@ -19,7 +19,7 @@
         "ajv": "^8.17.1",
         "chai": "^4.3.0",
         "chai-as-promised": "^7.1.1",
-        "mfkdf": "github:multifactor/MFKDF#test/differential-testing",
+        "mfkdf": "github:multifactor/MFKDF#3d5bf7",
         "mocha": "^10.0.0",
         "mocha-junit-reporter": "^2.2.1",
         "mocha-multi-reporters": "^1.5.1",

--- a/mfkdf2-web/package.json
+++ b/mfkdf2-web/package.json
@@ -61,6 +61,6 @@
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.2",
-    "mfkdf": "github:multifactor/MFKDF#test/differential-testing"
+    "mfkdf": "github:multifactor/MFKDF#3d5bf7"
   }
 }

--- a/mfkdf2-web/test/factors/hmacsha1.test.ts
+++ b/mfkdf2-web/test/factors/hmacsha1.test.ts
@@ -73,7 +73,7 @@ suite('factors/hmacsha1', () => {
     derive.key
       .toString('hex')
       .should.equal(
-        '2747ebf65219aee6630a758e40fd05ccbb39ab465745ea1c9a6c5adb6673d2d3'
+        'e1e67a0a2118867d8baf660d87500e650211855d2eff4c557ef2c8ae26ab5b6f'
       );
   });
 

--- a/mfkdf2/Cargo.toml
+++ b/mfkdf2/Cargo.toml
@@ -14,8 +14,11 @@ required-features = ["bindings"]
 [dependencies]
 # Cryptography
 aes = { version = "0.8", default-features = false }
+cbc = { version = "0.1.2", default-features = false }
 cipher = { version = "0.4", default-features = false, features = [
   "block-padding",
+  "rand_core",
+  "std",
 ] }
 ecb = { version = "0.1", default-features = false }
 hkdf = { version = "0.12", default-features = false }
@@ -83,6 +86,7 @@ data-encoding = { version = "2.9.0", default-features = false, features = [
   "alloc",
 ] }
 regex = { version = "1.11.3", default-features = false }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "1.0", default-features = false }

--- a/mfkdf2/README.md
+++ b/mfkdf2/README.md
@@ -276,6 +276,8 @@ a Shamir‑style secret sharing scheme, one share per factor. During derive, any
 that supplies at least `threshold` valid shares can reconstruct the same secret and therefore
 the same derived key.
 
+**Note**: MFKDF2 provides no mechanism to invalidate old policies. When threshold is increased via [reconstitution](`crate::definitions::mfkdf_derived_key::reconstitution`), old policies can still be used to derive keys.
+
 ## Setup: configuring a 2‑of‑3 recovery policy
 
 The snippet below constructs a 2‑of‑3 key from a password, an HOTP soft token, and a UUID
@@ -462,6 +464,13 @@ let derived = derive::key(
 
 The same outer key can also be derived with only `password3` by supplying a single password
 factor keyed by `"password3"` to [setup key](`crate::derive::key`).
+
+# Integrity Protetion
+
+
+MFKDF2 allows policy integrity to be enforced between each subsequent derives, and is enabled by default. An honest client will only accept a state if the key it derives from that state correctly validates the state’s integrity. Before deriving the final key, current policy's self-referential tag is checked. This is enabled using `verify` flag in [setup](`crate::setup::key`) and [derive](`crate::derive::key`). If any mismatch is detected, the [PolicyIntegrityCheckFailed](`crate::error::MFKDF2Error::PolicyIntegrityCheckFailed`) error is returned.
+
+When integrity is disabled, adversary can modify factor public state like threshold, factor parameters, encrypted shares. This may expose underlying keys and factor secrets, reducing the overall entropy of the key.
 
 # Feature Flags
 

--- a/mfkdf2/src/definitions/factor.rs
+++ b/mfkdf2/src/definitions/factor.rs
@@ -35,7 +35,7 @@ pub(crate) trait FactorMetadata: Send + Sync + std::fmt::Debug {
 ///
 /// ```rust
 /// use mfkdf2::{
-///   definitions::{FactorMetadata, FactorType},
+///   definitions::FactorType,
 ///   derive::factors::password as derive_password,
 ///   setup::factors::password::{PasswordOptions, password},
 /// };
@@ -48,7 +48,6 @@ pub(crate) trait FactorMetadata: Send + Sync + std::fmt::Debug {
 ///   _ => panic!("Wrong factor type"),
 /// };
 /// assert_eq!(p.password, "password123");
-/// assert_eq!(p.bytes(), "password123".as_bytes());
 ///
 /// // derive a key using the password factor
 /// let derive = derive_password("password123")?;

--- a/mfkdf2/src/definitions/mfkdf_derived_key/hints.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/hints.rs
@@ -10,9 +10,13 @@
 //! correct before attempting a full derivation.
 use std::fmt::Write;
 
-use base64::engine::general_purpose;
+use base64::{Engine, engine::general_purpose};
 
-use crate::{definitions::MFKDF2DerivedKey, error::MFKDF2Error};
+use crate::{
+  crypto::{hkdf_sha256_with_info, hmacsha256},
+  definitions::MFKDF2DerivedKey,
+  error::MFKDF2Error,
+};
 
 impl MFKDF2DerivedKey {
   /// Compute a probabilistic hint for a single factor.
@@ -135,10 +139,34 @@ impl MFKDF2DerivedKey {
   /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
   /// ```
   pub fn add_hint(&mut self, factor_id: &str, bits: Option<u8>) -> Result<(), MFKDF2Error> {
+    // verify policy integrity
+    if !self.policy.hmac.is_empty() {
+      let integrity_data = self.policy.extract();
+      let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+      let integrity_key = hkdf_sha256_with_info(&self.key, &salt, "mfkdf2:integrity".as_bytes());
+      let digest = hmacsha256(&integrity_key, &integrity_data);
+      let hmac = general_purpose::STANDARD.encode(digest);
+      if self.policy.hmac != hmac {
+        return Err(MFKDF2Error::PolicyIntegrityCheckFailed);
+      }
+    }
+
     let bits = bits.unwrap_or(7);
     let hint = self.get_hint(factor_id, bits);
     let factor_data = self.policy.factors.iter_mut().find(|f| f.id == factor_id).unwrap();
     factor_data.hint = Some(hint?);
+
+    // update the hmac of the policy
+    if !self.policy.hmac.is_empty() {
+      // compute the new hmac of the policy
+      let integrity_data = self.policy.extract();
+      let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+      let integrity_key = hkdf_sha256_with_info(&self.key, &salt, "mfkdf2:integrity".as_bytes());
+      let digest = hmacsha256(&integrity_key, &integrity_data);
+      let hmac = general_purpose::STANDARD.encode(digest);
+      self.policy.hmac = hmac;
+    }
+
     Ok(())
   }
 }
@@ -269,11 +297,129 @@ mod tests {
       &[crate::setup::factors::password("password1", PasswordOptions {
         id: Some("password1".to_string()),
       })?],
-      MFKDF2Options { integrity: Some(false), ..Default::default() },
+      MFKDF2Options { integrity: Some(true), ..Default::default() },
     )?;
 
     let result = setup_key.get_hint("password1", 0);
     assert!(matches!(result, Err(error::MFKDF2Error::InvalidHintLength(_))));
+
+    Ok(())
+  }
+
+  // Below tests demonstrate the entropy leakage of the hint feature. With integrity turned off, an
+  // adversary can modify the hint and derive the key successfully. If hint mismatches, then
+  // derivation fails with `HintMismatch` error. This leaks 1 bit of information for each
+  // derivation. The adversary can repeatedly guess the hint, launching a brute-force attack on the
+  // factor.
+  // If integrity is turned on, then the adversary cannot modify the hint and derive the key
+  // successfully. If hint mismatches, then derivation fails with `PolicyIntegrityCheckFailed`
+  // error. This does not leak any information about the factor.
+  #[test]
+  fn hint_entropy_leakage_no_integrity() -> Result<(), error::MFKDF2Error> {
+    let mut setup_key = setup::key(
+      &[crate::setup::factors::password("password1", PasswordOptions {
+        id: Some("password1".to_string()),
+      })?],
+      MFKDF2Options { integrity: Some(false), ..Default::default() },
+    )?;
+
+    // 7 bit hint added to the policy
+    setup_key.add_hint("password1", None)?;
+
+    // derive the key with the correct password
+    let derive_key = derive::key(
+      &setup_key.policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      false,
+      false,
+    )?;
+
+    assert_eq!(derive_key.key, setup_key.key);
+
+    // modify hint
+    let mut hint = setup_key.get_hint("password1", 7)?;
+    hint.insert(0, '0');
+
+    let mut modified_setup_key_policy = setup_key.policy.clone();
+    modified_setup_key_policy.factors[0].hint = Some(hint);
+
+    // derive the key with the modified hint
+    let mut modified_derive_key = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      false,
+      false,
+    );
+
+    if matches!(modified_derive_key, Err(error::MFKDF2Error::HintMismatch(_))) {
+      let mut hint = setup_key.get_hint("password1", 7)?;
+      hint.insert(0, '1');
+      modified_setup_key_policy.factors[0].hint = Some(hint);
+      modified_derive_key = derive::key(
+        &modified_setup_key_policy,
+        HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+        false,
+        false,
+      );
+    }
+
+    assert_eq!(modified_derive_key.unwrap().key, derive_key.key);
+
+    Ok(())
+  }
+
+  #[test]
+  fn hint_entropy_leakage_with_integrity() -> Result<(), error::MFKDF2Error> {
+    let mut setup_key = setup::key(
+      &[crate::setup::factors::password("password1", PasswordOptions {
+        id: Some("password1".to_string()),
+      })?],
+      MFKDF2Options { integrity: Some(true), ..Default::default() },
+    )?;
+
+    // 7 bit hint added to the policy
+    setup_key.add_hint("password1", None)?;
+
+    // derive the key with the correct password
+    let derive_key = derive::key(
+      &setup_key.policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    )?;
+
+    assert_eq!(derive_key.key, setup_key.key);
+
+    // modify hint
+    let mut hint = setup_key.get_hint("password1", 7)?;
+    hint.insert(0, '0');
+
+    let mut modified_setup_key_policy = setup_key.policy.clone();
+    modified_setup_key_policy.factors[0].hint = Some(hint);
+
+    // derive the key with the modified hint
+    let modified_derive_key1 = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    );
+
+    let mut modified_hint = setup_key.get_hint("password1", 7)?;
+    modified_hint.insert(0, '1');
+    modified_setup_key_policy.factors[0].hint = Some(modified_hint);
+
+    let modified_derive_key2 = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    );
+
+    assert!(
+      matches!(modified_derive_key1, Err(error::MFKDF2Error::PolicyIntegrityCheckFailed))
+        || matches!(modified_derive_key2, Err(error::MFKDF2Error::PolicyIntegrityCheckFailed))
+    );
 
     Ok(())
   }

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mfdpg.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mfdpg.rs
@@ -11,7 +11,7 @@
 use rand::{SeedableRng, distributions::Distribution};
 use rand_regex::Regex;
 
-use crate::error::MFKDF2Error;
+use crate::error::MFKDF2Result;
 
 impl crate::definitions::MFKDF2DerivedKey {
   /// Derives a deterministic, policy-compliant password from an `MFKDF2DerivedKey`
@@ -64,8 +64,8 @@ impl crate::definitions::MFKDF2DerivedKey {
     purpose: Option<&str>,
     salt: Option<&[u8]>,
     regex: &str,
-  ) -> Result<String, MFKDF2Error> {
-    let password_key = self.get_subkey(purpose, salt);
+  ) -> MFKDF2Result<String> {
+    let password_key = self.get_subkey(purpose, salt)?;
     // seed and rng with password_key
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(password_key);
     let dfa = Regex::compile(regex, 10000)?;
@@ -80,7 +80,7 @@ fn derived_key_derive_password(
   purpose: Option<String>,
   salt: Option<Vec<u8>>,
   regex: &str,
-) -> Result<String, MFKDF2Error> {
+) -> MFKDF2Result<String> {
   let purpose = purpose.as_deref();
   let salt = salt.as_deref();
   derived_key.derive_password(purpose, salt, regex)

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
@@ -11,12 +11,15 @@
 //! underlying multi-factor construction.
 use std::collections::HashMap;
 
+use argon2::Argon2;
 use base64::{Engine, engine::general_purpose};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+  crypto::decrypt,
   definitions::{bytearray::Key, entropy::MFKDF2Entropy},
+  error::MFKDF2Result,
   policy::Policy,
 };
 
@@ -62,5 +65,30 @@ impl std::fmt::Display for MFKDF2DerivedKey {
       general_purpose::STANDARD.encode(self.key.as_ref()),
       general_purpose::STANDARD.encode(self.secret.clone()),
     )
+  }
+}
+
+impl MFKDF2DerivedKey {
+  /// Derive an internal key for deriving separate keys for parameters, secret, and integrity
+  /// using the policy salt and secret.
+  fn derive_internal_key(&self) -> MFKDF2Result<Key> {
+    let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+
+    let mut kek = [0u8; 32];
+    Argon2::new(
+      argon2::Algorithm::Argon2id,
+      argon2::Version::default(),
+      argon2::Params::new(
+        argon2::Params::DEFAULT_M_COST + self.policy.memory,
+        argon2::Params::DEFAULT_T_COST + self.policy.time,
+        1,
+        Some(32),
+      )?,
+    )
+    .hash_password_into(&self.secret, &salt, &mut kek)?;
+
+    let policy_key = general_purpose::STANDARD.decode(&self.policy.key)?;
+    let key = decrypt(policy_key, &kek);
+    key.try_into()
   }
 }

--- a/mfkdf2/src/definitions/mfkdf_derived_key/reconstitution.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/reconstitution.rs
@@ -6,6 +6,9 @@
 //! Consider a key derived from a password, a TOTP factor, and a UUID factor. Using threshold
 //! recovery, the user can derive the key with only a subset of factors inside the policy.
 //!
+//! **Note**: MFKDF2 provides no mechanism to invalidate old policies. When threshold is increased
+//! via reconstitution, old policies can still be used to derive keys.
+//!
 //! ```rust
 //! # use std::collections::HashMap;
 //! # use uuid::Uuid;

--- a/mfkdf2/src/definitions/mfkdf_derived_key/strengthening.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/strengthening.rs
@@ -93,6 +93,10 @@ impl MFKDF2DerivedKey {
   /// [`crate::error::MFKDF2Error::PolicyIntegrityCheckFailed`] if an attacker attempts to
   /// weaken or roll back the policy, as that invalidates the integrity MAC.
   pub fn strengthen(&mut self, time: u32, memory: u32) -> MFKDF2Result<()> {
+    // derive internal key
+    let internal_key = self.derive_internal_key()?;
+
+    // update policy time and memory
     self.policy.time = time;
     self.policy.memory = memory;
 
@@ -112,7 +116,7 @@ impl MFKDF2DerivedKey {
     )
     .hash_password_into(&self.secret, &salt, &mut kek)?;
 
-    let policy_key = encrypt(self.key.as_ref(), &kek);
+    let policy_key = encrypt(&internal_key, &kek);
     self.policy.key = general_purpose::STANDARD.encode(policy_key);
     Ok(())
   }

--- a/mfkdf2/src/error.rs
+++ b/mfkdf2/src/error.rs
@@ -113,4 +113,10 @@ pub enum MFKDF2Error {
 
   #[error(transparent)]
   Regex(#[from] rand_regex::Error),
+
+  #[error(transparent)]
+  Encrypt(#[from] cipher::inout::PadError),
+
+  #[error(transparent)]
+  Decrypt(#[from] cipher::inout::block_padding::UnpadError),
 }

--- a/mfkdf2/src/integrity.rs
+++ b/mfkdf2/src/integrity.rs
@@ -62,6 +62,7 @@ pub fn extract_factor_core(factor: &PolicyFactor) -> [u8; 32] {
   hasher.update(factor.pad.as_bytes());
   hasher.update(factor.salt.as_bytes());
   hasher.update(factor.secret.as_bytes());
+  hasher.update(factor.hint.as_ref().unwrap_or(&String::new()).as_bytes());
 
   hasher.finalize().into()
 }

--- a/mfkdf2/src/setup/key.rs
+++ b/mfkdf2/src/setup/key.rs
@@ -217,8 +217,9 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   let mut secret: [u8; 32] = [0u8; 32];
   crate::rng::fill_bytes(&mut secret);
 
-  let mut key = [0u8; 32];
-  crate::rng::fill_bytes(&mut key);
+  // Create an internal key for deriving separate keys for parameters, secret, and integrity
+  let mut internal_key = [0u8; 32];
+  crate::rng::fill_bytes(&mut internal_key);
 
   // Generate key
   let mut kek = [0u8; 32];
@@ -241,7 +242,7 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   }
 
   // policy key
-  let policy_key = encrypt(&key, &kek);
+  let policy_key = encrypt(&internal_key, &kek);
 
   // Split secret into Shamir shares
   let dealer =
@@ -273,13 +274,13 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
 
     // Generate factor key
     let params_key =
-      hkdf_sha256_with_info(&key, &salt, format!("mfkdf2:factor:params:{id}").as_bytes());
+      hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:params:{id}").as_bytes());
     let params = factor.factor_type.setup().params(params_key.into())?;
 
     outputs.insert(id.clone(), factor.factor_type.output());
 
     let secret_key =
-      hkdf_sha256_with_info(&key, &salt, format!("mfkdf2:factor:secret:{id}").as_bytes());
+      hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:secret:{id}").as_bytes());
     let factor_secret = encrypt(&stretched, &secret_key);
 
     // Record entropy statistics (in bits) for this factor.
@@ -313,7 +314,7 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   // Derive an integrity key specific to the policy and compute a policy HMAC
   if options.integrity.unwrap_or(true) {
     let integrity_data = policy.extract();
-    let integrity_key = hkdf_sha256_with_info(&key, &salt, "mfkdf2:integrity".as_bytes());
+    let integrity_key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:integrity".as_bytes());
     let digest = hmacsha256(&integrity_key, &integrity_data);
     policy.hmac = general_purpose::STANDARD.encode(digest);
   }
@@ -328,9 +329,14 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   let entropy_theoretical = theoretical_sum.min(256);
   let entropy_real = real_sum.min(256.0);
 
+  // derive a dedicated final key to ensure domain separation between internal and external keys
+  if !options.stack.unwrap_or(false) {
+    internal_key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
+  }
+
   Ok(MFKDF2DerivedKey {
     policy,
-    key: key.into(),
+    key: internal_key.into(),
     secret: secret.to_vec(),
     shares,
     outputs,
@@ -464,7 +470,8 @@ mod tests {
     .unwrap();
 
     let policy_key = general_purpose::STANDARD.decode(derived_key.policy.key.clone()).unwrap();
-    let key = decrypt(policy_key, &kek);
+    let internal_key = decrypt(policy_key, &kek);
+    let key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
 
     assert_eq!(derived_key.policy.id, options.id.unwrap());
     assert_eq!(derived_key.policy.threshold as usize, factors.len());
@@ -472,13 +479,13 @@ mod tests {
     assert_eq!(derived_key.policy.time, options.time.unwrap());
     assert_eq!(derived_key.policy.memory, options.memory.unwrap());
 
-    assert_eq!(derived_key.key, key.clone().try_into().unwrap());
+    assert_eq!(derived_key.key, key.into());
 
     // verify factor secret is encrypted with key
     let mut shares = Vec::new();
     for factor in &derived_key.policy.factors {
       let secret_key = hkdf_sha256_with_info(
-        &key,
+        &internal_key,
         &general_purpose::STANDARD.decode(factor.salt.clone()).unwrap(),
         format!("mfkdf2:factor:secret:{}", &factor.id).as_bytes(),
       );
@@ -533,8 +540,9 @@ mod tests {
     .unwrap();
 
     let policy_key = general_purpose::STANDARD.decode(derived_key.policy.key.clone()).unwrap();
-    let key = decrypt(policy_key, &kek);
-    assert_eq!(derived_key.key, key.clone().try_into().unwrap());
+    let internal_key = decrypt(policy_key, &kek);
+    let key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
+    assert_eq!(derived_key.key, key.into());
 
     let shares_to_recover: Vec<Vec<u8>> =
       derived_key.shares.iter().take(threshold as usize).cloned().collect();


### PR DESCRIPTION
Audit fixes:
- #56
- #57 
- #59 

Not done:
- F2: secret material data is not stored in policy anywhere, so during hint addition we decrypt stretched factor material to derive the hint key.
- F4: Mentioned in the docs, but no specific changes made to library.
- F5: Integrity protection is already true by default, but library delegate the decision to user at the end.