### PR TITLE
feat: zeroize

### DIFF
--- a/.github/workflows/differential.yaml
+++ b/.github/workflows/differential.yaml
@@ -1,23 +1,23 @@
-name: Bindings
+name: Differential Tests
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  bindings-generation:
-    name: ts
+  differential-tests:
+    name: differential
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout pinned mfkdf2.rs commit
+        uses: actions/checkout@v4
+        with:
+          ref: 7c33c7164d6e40a26c0899f19b8f9ad9b9f0c029
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -28,7 +28,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: typescript/bindings
+          key: typescript/differential
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,9 +56,9 @@ jobs:
         working-directory: mfkdf2-web
         run: npm ci
 
-      - name: Generate TypeScript bindings
+      - name: Generate TypeScript bindings for differential tests
         working-directory: mfkdf2-web
-        run: npm run ubrn:web:release
+        run: npm run ubrn:web:differential:release
 
       - name: Copy index.web.ts implementation
         run: cp mfkdf2-web/src/index.ts mfkdf2-web/src/index.web.ts
@@ -75,25 +75,8 @@ jobs:
           fi
           echo "✓ TypeScript bindings verified"
 
-      - name: Run TypeScript tests with reports
+      - name: Run differential tests
         working-directory: mfkdf2-web
-        run: npm run test:report
+        run: npm run test:differential
 
-      - name: Publish JUnit test report
-        if: always()
-        uses: mikepenz/action-junit-report@v4
-        with:
-          report_paths: "mfkdf2-web/test-results/junit/junit.xml"
-          detailed_summary: true
-          include_passed: true
 
-      - name: Upload HTML test report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mfkdf2-web-mochawesome-report
-          path: mfkdf2-web/test-results/mochawesome/
-
-      - name: Run TypeScript type checking
-        working-directory: mfkdf2-web
-        run: npm run typecheck

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -187,7 +187,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run cargo-llvm-cov
-        run: cargo llvm-cov --all-features --workspace --html --output-dir target/coverage
+        run: cargo llvm-cov --workspace --html --output-dir target/coverage
 
       - name: Upload coverage to Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -119,6 +119,9 @@ jobs:
 
       - name: Run tests (JUnit)
         run: cargo nextest run --release --profile ci
+      
+      - name: Run doctests
+        run: cargo test --release --doc
 
       - name: Publish JUnit test report
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "uniffi",
  "uuid",
  "web-time",
+ "zeroize",
  "zxcvbn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -964,6 +974,7 @@ dependencies = [
  "aes",
  "argon2",
  "base64",
+ "cbc",
  "cipher",
  "console_log",
  "criterion",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,7 @@ Please check here before filing new reports.
 | Affected Version(s) | Description                                                            | Status       | CVE / Advisory |
 | ------------------- | ---------------------------------------------------------------------- | ------------ | -------------- |
 | 0.0.1               | RSA Marvin Attack: potential key recovery through timing sidechannels. | 🔴 Unresolved | 2023-49092     |
+| 0.0.1               | Generic-Array: v0.14.9 is deprecated but used by aes-v0.8.4            | 🔴 Unresolved | -              |
 
 Legend:
 - 🟢 Fixed

--- a/docs/src/differential-tests.md
+++ b/docs/src/differential-tests.md
@@ -31,19 +31,26 @@ See: [multifactor/MFKDF#27](https://github.com/multifactor/MFKDF/pull/27)
 See: [multifactor/MFKDF2.rs#43](https://github.com/multifactor/MFKDF2.rs/pull/43)
 - Add a `differential-test` feature flag providing a global deterministic RNG equivalent to the reference.
 - Provide utility methods in the TypeScript bindings facade for nested parameter parsing and stringification (read/write inner params) to match reference structures.
+- Pin the versions used for differential testing to:
+  - `MFKDF2.rs` commit `7c33c7164d6e40a26c0899f19b8f9ad9b9f0c029`
+  - `MFKDF` commit `3d5bf73b4ce42b23da113b4be6d35e7d941fadf8`
 
 ## How to reproduce
 
-Run the differential tests using the bindings workflow. From the repository root:
+You can run the differential tests **locally** or via the **GitHub Actions workflow**.
+
+### Locally
+
+From the repository root:
 
 ```bash
 # Ensure the WASM target is present (one-time)
 rustup target add wasm32-unknown-unknown
 
-# Generate differential-release bindings (optimized)
+# Generate differential-release bindings (includes the `differential-test` feature)
 just gen-ts-bindings-differential
 
-# Run the TypeScript test suite (includes differential tests)
+# Run only the differential TypeScript test suite
 just test-bindings-differential
 ```
 

--- a/mfkdf2-web/package-lock.json
+++ b/mfkdf2-web/package-lock.json
@@ -19,7 +19,7 @@
         "ajv": "^8.17.1",
         "chai": "^4.3.0",
         "chai-as-promised": "^7.1.1",
-        "mfkdf": "github:multifactor/MFKDF#test/differential-testing",
+        "mfkdf": "github:multifactor/MFKDF#3d5bf7",
         "mocha": "^10.0.0",
         "mocha-junit-reporter": "^2.2.1",
         "mocha-multi-reporters": "^1.5.1",

--- a/mfkdf2-web/package.json
+++ b/mfkdf2-web/package.json
@@ -61,6 +61,6 @@
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.2",
-    "mfkdf": "github:multifactor/MFKDF#test/differential-testing"
+    "mfkdf": "github:multifactor/MFKDF#3d5bf7"
   }
 }

--- a/mfkdf2-web/test/factors/hmacsha1.test.ts
+++ b/mfkdf2-web/test/factors/hmacsha1.test.ts
@@ -73,7 +73,7 @@ suite('factors/hmacsha1', () => {
     derive.key
       .toString('hex')
       .should.equal(
-        '2747ebf65219aee6630a758e40fd05ccbb39ab465745ea1c9a6c5adb6673d2d3'
+        'e1e67a0a2118867d8baf660d87500e650211855d2eff4c557ef2c8ae26ab5b6f'
       );
   });
 

--- a/mfkdf2/Cargo.toml
+++ b/mfkdf2/Cargo.toml
@@ -14,8 +14,11 @@ required-features = ["bindings"]
 [dependencies]
 # Cryptography
 aes = { version = "0.8", default-features = false }
+cbc = { version = "0.1.2", default-features = false }
 cipher = { version = "0.4", default-features = false, features = [
   "block-padding",
+  "rand_core",
+  "std",
 ] }
 ecb = { version = "0.1", default-features = false }
 hkdf = { version = "0.12", default-features = false }
@@ -83,6 +86,7 @@ data-encoding = { version = "2.9.0", default-features = false, features = [
   "alloc",
 ] }
 regex = { version = "1.11.3", default-features = false }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = { version = "1.0", default-features = false }

--- a/mfkdf2/Cargo.toml
+++ b/mfkdf2/Cargo.toml
@@ -86,6 +86,10 @@ data-encoding = { version = "2.9.0", default-features = false, features = [
   "alloc",
 ] }
 regex = { version = "1.11.3", default-features = false }
+zeroize = { version = "1.8.2", optional = true, default-features = false, features = [
+  "zeroize_derive",
+  "alloc",
+] }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -159,10 +163,11 @@ name    = "reconstitution"
 path    = "benches/reconstitution.rs"
 
 [features]
-default = []
+default = ["zeroize"]
 # Enable UniFFI bindings (FFI exports, scaffolding, bin, etc.)
 bindings          = ["dep:uniffi"]
 differential-test = []
+zeroize           = ["dep:zeroize"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/mfkdf2/README.md
+++ b/mfkdf2/README.md
@@ -276,6 +276,8 @@ a Shamir‑style secret sharing scheme, one share per factor. During derive, any
 that supplies at least `threshold` valid shares can reconstruct the same secret and therefore
 the same derived key.
 
+**Note**: MFKDF2 provides no mechanism to invalidate old policies. When threshold is increased via [reconstitution](`crate::definitions::mfkdf_derived_key::reconstitution`), old policies can still be used to derive keys.
+
 ## Setup: configuring a 2‑of‑3 recovery policy
 
 The snippet below constructs a 2‑of‑3 key from a password, an HOTP soft token, and a UUID
@@ -462,6 +464,13 @@ let derived = derive::key(
 
 The same outer key can also be derived with only `password3` by supplying a single password
 factor keyed by `"password3"` to [setup key](`crate::derive::key`).
+
+# Integrity Protetion
+
+
+MFKDF2 allows policy integrity to be enforced between each subsequent derives, and is enabled by default. An honest client will only accept a state if the key it derives from that state correctly validates the state’s integrity. Before deriving the final key, current policy's self-referential tag is checked. This is enabled using `verify` flag in [setup](`crate::setup::key`) and [derive](`crate::derive::key`). If any mismatch is detected, the [PolicyIntegrityCheckFailed](`crate::error::MFKDF2Error::PolicyIntegrityCheckFailed`) error is returned.
+
+When integrity is disabled, adversary can modify factor public state like threshold, factor parameters, encrypted shares. This may expose underlying keys and factor secrets, reducing the overall entropy of the key.
 
 # Feature Flags
 

--- a/mfkdf2/README.md
+++ b/mfkdf2/README.md
@@ -195,7 +195,7 @@ let derive_password_factor = derive_password("password123")?;
 #    .finalize()
 #    .into_bytes()
 #    .into();
-let derive_hmac_factor = derive_hmacsha1(response.into())?;
+let derive_hmac_factor = derive_hmacsha1(response)?;
 #
 # let policy_hotp_factor = setup_derived_key
 #   .policy

--- a/mfkdf2/benches/hmacsha1.rs
+++ b/mfkdf2/benches/hmacsha1.rs
@@ -6,7 +6,7 @@ use mfkdf2::{
   derive,
   setup::{
     self,
-    factors::hmacsha1::{HmacSha1Options, HmacSha1Response, hmacsha1},
+    factors::hmacsha1::{HmacSha1Options, hmacsha1},
   },
 };
 
@@ -44,7 +44,7 @@ fn bench_hmacsha1(c: &mut Criterion) {
     b.iter(|| {
       let factors_map = black_box(HashMap::from([(
         "hmac".to_string(),
-        derive::factors::hmacsha1(HmacSha1Response(SECRET20)).unwrap(),
+        derive::factors::hmacsha1(SECRET20).unwrap(),
       )]));
       let result = black_box(derive::key(&single_setup_key.policy, factors_map, false, false));
       result.unwrap()
@@ -107,19 +107,19 @@ fn bench_hmacsha1(c: &mut Criterion) {
   group.bench_function("multiple_derive_3", |b| {
     b.iter(|| {
       let factors_map = black_box(HashMap::from([
-        ("hmac1".to_string(), derive::factors::hmacsha1(HmacSha1Response(SECRET20)).unwrap()),
+        ("hmac1".to_string(), derive::factors::hmacsha1(SECRET20).unwrap()),
         (
           "hmac2".to_string(),
-          derive::factors::hmacsha1(HmacSha1Response([
+          derive::factors::hmacsha1([
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-          ]))
+          ])
           .unwrap(),
         ),
         (
           "hmac3".to_string(),
-          derive::factors::hmacsha1(HmacSha1Response([
+          derive::factors::hmacsha1([
             21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-          ]))
+          ])
           .unwrap(),
         ),
       ]));
@@ -156,12 +156,12 @@ fn bench_hmacsha1(c: &mut Criterion) {
   group.bench_function("threshold_derive_2_of_3", |b| {
     b.iter(|| {
       let factors_map = black_box(HashMap::from([
-        ("hmac1".to_string(), derive::factors::hmacsha1(HmacSha1Response(SECRET20)).unwrap()),
+        ("hmac1".to_string(), derive::factors::hmacsha1(SECRET20).unwrap()),
         (
           "hmac2".to_string(),
-          derive::factors::hmacsha1(HmacSha1Response([
+          derive::factors::hmacsha1([
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-          ]))
+          ])
           .unwrap(),
         ),
       ]));

--- a/mfkdf2/src/crypto.rs
+++ b/mfkdf2/src/crypto.rs
@@ -20,7 +20,7 @@ pub(crate) fn hkdf_sha256_with_info(input: &[u8], salt: &[u8], info: &[u8]) -> [
 }
 
 /// Encrypts a buffer using AES256-ECB with the given 32-byte key.
-pub(crate) fn encrypt(data: &[u8], key: &[u8; 32]) -> Vec<u8> {
+pub(crate) fn encrypt(data: &[u8], key: impl AsRef<[u8]>) -> Vec<u8> {
   // Ensure the input is a multiple of 16 by zero-padding if necessary.
   let mut buf = {
     let mut v = data.to_vec();
@@ -31,7 +31,7 @@ pub(crate) fn encrypt(data: &[u8], key: &[u8; 32]) -> Vec<u8> {
     v
   };
 
-  let cipher = Encryptor::<Aes256>::new_from_slice(key).expect("Invalid AES-256 key");
+  let cipher = Encryptor::<Aes256>::new_from_slice(key.as_ref()).expect("Invalid AES-256 key");
   let padded_len = buf.len(); // now guaranteed multiple of 16
   cipher.encrypt_padded_mut::<NoPadding>(&mut buf, padded_len).expect("ECB encryption");
   buf
@@ -63,8 +63,8 @@ where
 
 /// Decrypts a buffer using AES256-ECB with the given 32-byte key.
 // TODO (@lonerapier): check every use of decrypt and unpad properly or use assert.
-pub(crate) fn decrypt(mut data: Vec<u8>, key: &[u8; 32]) -> Vec<u8> {
-  let cipher = Decryptor::<Aes256>::new_from_slice(key).expect("Invalid AES key");
+pub(crate) fn decrypt(mut data: Vec<u8>, key: impl AsRef<[u8]>) -> Vec<u8> {
+  let cipher = Decryptor::<Aes256>::new_from_slice(key.as_ref()).expect("Invalid AES key");
   let _ = cipher.decrypt_padded_mut::<NoPadding>(&mut data).expect("ECB decrypt");
   data
 }

--- a/mfkdf2/src/definitions/bytearray.rs
+++ b/mfkdf2/src/definitions/bytearray.rs
@@ -43,38 +43,45 @@ impl<const N: usize> std::ops::Deref for ByteArray<N> {
   fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-// Implement traits specifically for 32‑byte keys to satisfy serde and default bounds.
+// Macro to implement Default, Serialize, and Deserialize for fixed-size ByteArrays
+macro_rules! impl_bytearray {
+  ($N:expr) => {
+    impl Default for ByteArray<$N> {
+      fn default() -> Self { ByteArray([0u8; $N]) }
+    }
 
-impl Default for ByteArray<32> {
-  fn default() -> Self { ByteArray([0u8; 32]) }
-}
-
-impl Serialize for ByteArray<32> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where S: serde::Serializer {
-    serializer.serialize_newtype_struct("Key", &self.0)
-  }
-}
-
-impl<'de> Deserialize<'de> for ByteArray<32> {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where D: serde::Deserializer<'de> {
-    struct KeyVisitor;
-
-    impl<'de> serde::de::Visitor<'de> for KeyVisitor {
-      type Value = ByteArray<32>;
-
-      fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a 32-byte array for Key")
-      }
-
-      fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-      where D: serde::Deserializer<'de> {
-        let bytes = <[u8; 32]>::deserialize(deserializer)?;
-        Ok(ByteArray(bytes))
+    impl Serialize for ByteArray<$N> {
+      fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+      where S: serde::Serializer {
+        serializer.serialize_newtype_struct(stringify!(ByteArray), &self.0)
       }
     }
 
-    deserializer.deserialize_newtype_struct("Key", KeyVisitor)
-  }
+    impl<'de> Deserialize<'de> for ByteArray<$N> {
+      fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+      where D: serde::Deserializer<'de> {
+        struct ByteArrayVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ByteArrayVisitor {
+          type Value = ByteArray<$N>;
+
+          fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "a {}-byte array", $N)
+          }
+
+          fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+          where D: serde::Deserializer<'de> {
+            let bytes = <[u8; $N]>::deserialize(deserializer)?;
+            Ok(ByteArray(bytes))
+          }
+        }
+
+        deserializer.deserialize_newtype_struct(stringify!(ByteArray), ByteArrayVisitor)
+      }
+    }
+  };
 }
+
+// Implement for 20-byte and 32-byte arrays
+impl_bytearray!(20);
+impl_bytearray!(32);

--- a/mfkdf2/src/definitions/bytearray.rs
+++ b/mfkdf2/src/definitions/bytearray.rs
@@ -3,9 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 /// Generic fixed-size byte array used as the basis for key-like types.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
-pub struct ByteArray<const N: usize>(pub [u8; N]);
+pub struct ByteArray<const N: usize>([u8; N]);
 
 /// 32 byte key
 pub type Key = ByteArray<32>;

--- a/mfkdf2/src/definitions/bytearray.rs
+++ b/mfkdf2/src/definitions/bytearray.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Generic fixed-size byte array used as the basis for key-like types.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct ByteArray<const N: usize>(pub [u8; N]);
 
 /// 32 byte key

--- a/mfkdf2/src/definitions/entropy.rs
+++ b/mfkdf2/src/definitions/entropy.rs
@@ -7,8 +7,9 @@
 ///
 /// We recommend using "real" for most practical purposes. Entropy is only provided on key setup and
 /// is not available on subsequent derivations.
-#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, PartialEq)]
+#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct MFKDF2Entropy {
   /// Conservative estimate based on how the factor is actually produced or used. Calculated
   /// using Dropbox's `zxcvbn` estimator.

--- a/mfkdf2/src/definitions/entropy.rs
+++ b/mfkdf2/src/definitions/entropy.rs
@@ -9,7 +9,6 @@
 /// is not available on subsequent derivations.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, PartialEq)]
 #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
-#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct MFKDF2Entropy {
   /// Conservative estimate based on how the factor is actually produced or used. Calculated
   /// using Dropbox's `zxcvbn` estimator.

--- a/mfkdf2/src/definitions/factor.rs
+++ b/mfkdf2/src/definitions/factor.rs
@@ -35,7 +35,7 @@ pub(crate) trait FactorMetadata: Send + Sync + std::fmt::Debug {
 ///
 /// ```rust
 /// use mfkdf2::{
-///   definitions::{FactorMetadata, FactorType},
+///   definitions::FactorType,
 ///   derive::factors::password as derive_password,
 ///   setup::factors::password::{PasswordOptions, password},
 /// };
@@ -48,7 +48,6 @@ pub(crate) trait FactorMetadata: Send + Sync + std::fmt::Debug {
 ///   _ => panic!("Wrong factor type"),
 /// };
 /// assert_eq!(p.password, "password123");
-/// assert_eq!(p.bytes(), "password123".as_bytes());
 ///
 /// // derive a key using the password factor
 /// let derive = derive_password("password123")?;

--- a/mfkdf2/src/definitions/factor.rs
+++ b/mfkdf2/src/definitions/factor.rs
@@ -59,8 +59,9 @@ pub(crate) trait FactorMetadata: Send + Sync + std::fmt::Debug {
 /// assert_eq!(derive.data(), "password123".as_bytes());
 /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
 /// ```
-#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
 #[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
 pub struct MFKDF2Factor {
   /// Optional application-defined identifier for the factor.
   pub id:          Option<String>,
@@ -99,6 +100,7 @@ impl std::fmt::Debug for MFKDF2Factor {
 /// which define the common interface for factor management, setup, and derivation.
 #[cfg_attr(feature = "bindings", derive(uniffi::Enum))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
 pub enum FactorType {
   /// [`password::Password`] factor.
   Password(password::Password),

--- a/mfkdf2/src/definitions/mfkdf_derived_key/crypto.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/crypto.rs
@@ -7,9 +7,17 @@ impl crate::definitions::MFKDF2DerivedKey {
     let purpose = purpose.unwrap_or("");
 
     // derive internal key
-    let internal_key = self.derive_internal_key()?;
+    let mut internal_key = self.derive_internal_key()?;
     // derive subkey
-    Ok(crate::crypto::hkdf_sha256_with_info(&internal_key, salt, purpose.as_bytes()))
+    let subkey = crate::crypto::hkdf_sha256_with_info(&internal_key, salt, purpose.as_bytes());
+
+    #[cfg(feature = "zeroize")]
+    {
+      use zeroize::Zeroize;
+      internal_key.zeroize();
+    }
+
+    Ok(subkey)
   }
 }
 

--- a/mfkdf2/src/definitions/mfkdf_derived_key/hints.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/hints.rs
@@ -10,9 +10,13 @@
 //! correct before attempting a full derivation.
 use std::fmt::Write;
 
-use base64::engine::general_purpose;
+use base64::{Engine, engine::general_purpose};
 
-use crate::{definitions::MFKDF2DerivedKey, error::MFKDF2Error};
+use crate::{
+  crypto::{hkdf_sha256_with_info, hmacsha256},
+  definitions::MFKDF2DerivedKey,
+  error::MFKDF2Error,
+};
 
 impl MFKDF2DerivedKey {
   /// Compute a probabilistic hint for a single factor.
@@ -135,10 +139,34 @@ impl MFKDF2DerivedKey {
   /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
   /// ```
   pub fn add_hint(&mut self, factor_id: &str, bits: Option<u8>) -> Result<(), MFKDF2Error> {
+    // verify policy integrity
+    if !self.policy.hmac.is_empty() {
+      let integrity_data = self.policy.extract();
+      let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+      let integrity_key = hkdf_sha256_with_info(&self.key, &salt, "mfkdf2:integrity".as_bytes());
+      let digest = hmacsha256(&integrity_key, &integrity_data);
+      let hmac = general_purpose::STANDARD.encode(digest);
+      if self.policy.hmac != hmac {
+        return Err(MFKDF2Error::PolicyIntegrityCheckFailed);
+      }
+    }
+
     let bits = bits.unwrap_or(7);
     let hint = self.get_hint(factor_id, bits);
     let factor_data = self.policy.factors.iter_mut().find(|f| f.id == factor_id).unwrap();
     factor_data.hint = Some(hint?);
+
+    // update the hmac of the policy
+    if !self.policy.hmac.is_empty() {
+      // compute the new hmac of the policy
+      let integrity_data = self.policy.extract();
+      let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+      let integrity_key = hkdf_sha256_with_info(&self.key, &salt, "mfkdf2:integrity".as_bytes());
+      let digest = hmacsha256(&integrity_key, &integrity_data);
+      let hmac = general_purpose::STANDARD.encode(digest);
+      self.policy.hmac = hmac;
+    }
+
     Ok(())
   }
 }
@@ -269,11 +297,129 @@ mod tests {
       &[crate::setup::factors::password("password1", PasswordOptions {
         id: Some("password1".to_string()),
       })?],
-      MFKDF2Options { integrity: Some(false), ..Default::default() },
+      MFKDF2Options { integrity: Some(true), ..Default::default() },
     )?;
 
     let result = setup_key.get_hint("password1", 0);
     assert!(matches!(result, Err(error::MFKDF2Error::InvalidHintLength(_))));
+
+    Ok(())
+  }
+
+  // Below tests demonstrate the entropy leakage of the hint feature. With integrity turned off, an
+  // adversary can modify the hint and derive the key successfully. If hint mismatches, then
+  // derivation fails with `HintMismatch` error. This leaks 1 bit of information for each
+  // derivation. The adversary can repeatedly guess the hint, launching a brute-force attack on the
+  // factor.
+  // If integrity is turned on, then the adversary cannot modify the hint and derive the key
+  // successfully. If hint mismatches, then derivation fails with `PolicyIntegrityCheckFailed`
+  // error. This does not leak any information about the factor.
+  #[test]
+  fn hint_entropy_leakage_no_integrity() -> Result<(), error::MFKDF2Error> {
+    let mut setup_key = setup::key(
+      &[crate::setup::factors::password("password1", PasswordOptions {
+        id: Some("password1".to_string()),
+      })?],
+      MFKDF2Options { integrity: Some(false), ..Default::default() },
+    )?;
+
+    // 7 bit hint added to the policy
+    setup_key.add_hint("password1", None)?;
+
+    // derive the key with the correct password
+    let derive_key = derive::key(
+      &setup_key.policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      false,
+      false,
+    )?;
+
+    assert_eq!(derive_key.key, setup_key.key);
+
+    // modify hint
+    let mut hint = setup_key.get_hint("password1", 7)?;
+    hint.insert(0, '0');
+
+    let mut modified_setup_key_policy = setup_key.policy.clone();
+    modified_setup_key_policy.factors[0].hint = Some(hint);
+
+    // derive the key with the modified hint
+    let mut modified_derive_key = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      false,
+      false,
+    );
+
+    if matches!(modified_derive_key, Err(error::MFKDF2Error::HintMismatch(_))) {
+      let mut hint = setup_key.get_hint("password1", 7)?;
+      hint.insert(0, '1');
+      modified_setup_key_policy.factors[0].hint = Some(hint);
+      modified_derive_key = derive::key(
+        &modified_setup_key_policy,
+        HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+        false,
+        false,
+      );
+    }
+
+    assert_eq!(modified_derive_key.unwrap().key, derive_key.key);
+
+    Ok(())
+  }
+
+  #[test]
+  fn hint_entropy_leakage_with_integrity() -> Result<(), error::MFKDF2Error> {
+    let mut setup_key = setup::key(
+      &[crate::setup::factors::password("password1", PasswordOptions {
+        id: Some("password1".to_string()),
+      })?],
+      MFKDF2Options { integrity: Some(true), ..Default::default() },
+    )?;
+
+    // 7 bit hint added to the policy
+    setup_key.add_hint("password1", None)?;
+
+    // derive the key with the correct password
+    let derive_key = derive::key(
+      &setup_key.policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    )?;
+
+    assert_eq!(derive_key.key, setup_key.key);
+
+    // modify hint
+    let mut hint = setup_key.get_hint("password1", 7)?;
+    hint.insert(0, '0');
+
+    let mut modified_setup_key_policy = setup_key.policy.clone();
+    modified_setup_key_policy.factors[0].hint = Some(hint);
+
+    // derive the key with the modified hint
+    let modified_derive_key1 = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    );
+
+    let mut modified_hint = setup_key.get_hint("password1", 7)?;
+    modified_hint.insert(0, '1');
+    modified_setup_key_policy.factors[0].hint = Some(modified_hint);
+
+    let modified_derive_key2 = derive::key(
+      &modified_setup_key_policy,
+      HashMap::from([("password1".to_string(), derive_factors::password("password1")?)]),
+      true,
+      false,
+    );
+
+    assert!(
+      matches!(modified_derive_key1, Err(error::MFKDF2Error::PolicyIntegrityCheckFailed))
+        || matches!(modified_derive_key2, Err(error::MFKDF2Error::PolicyIntegrityCheckFailed))
+    );
 
     Ok(())
   }

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mfdpg.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mfdpg.rs
@@ -11,7 +11,7 @@
 use rand::{SeedableRng, distributions::Distribution};
 use rand_regex::Regex;
 
-use crate::error::MFKDF2Error;
+use crate::error::MFKDF2Result;
 
 impl crate::definitions::MFKDF2DerivedKey {
   /// Derives a deterministic, policy-compliant password from an `MFKDF2DerivedKey`
@@ -64,8 +64,8 @@ impl crate::definitions::MFKDF2DerivedKey {
     purpose: Option<&str>,
     salt: Option<&[u8]>,
     regex: &str,
-  ) -> Result<String, MFKDF2Error> {
-    let password_key = self.get_subkey(purpose, salt);
+  ) -> MFKDF2Result<String> {
+    let password_key = self.get_subkey(purpose, salt)?;
     // seed and rng with password_key
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(password_key);
     let dfa = Regex::compile(regex, 10000)?;
@@ -80,7 +80,7 @@ fn derived_key_derive_password(
   purpose: Option<String>,
   salt: Option<Vec<u8>>,
   regex: &str,
-) -> Result<String, MFKDF2Error> {
+) -> MFKDF2Result<String> {
   let purpose = purpose.as_deref();
   let salt = salt.as_deref();
   derived_key.derive_password(purpose, salt, regex)

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
@@ -9,6 +9,7 @@
 //! key, while the embedded [`Policy`] and threshold secret-sharing scheme enable flexible recovery
 //! flows (such as `t`‑of‑`n` factor policies) without weakening the guarantees provided by the
 //! underlying multi-factor construction.
+#![cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
 use std::collections::HashMap;
 
 use argon2::Argon2;

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
@@ -11,12 +11,15 @@
 //! underlying multi-factor construction.
 use std::collections::HashMap;
 
+use argon2::Argon2;
 use base64::{Engine, engine::general_purpose};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+  crypto::decrypt,
   definitions::{bytearray::Key, entropy::MFKDF2Entropy},
+  error::MFKDF2Result,
   policy::Policy,
 };
 
@@ -62,5 +65,30 @@ impl std::fmt::Display for MFKDF2DerivedKey {
       general_purpose::STANDARD.encode(self.key.as_ref()),
       general_purpose::STANDARD.encode(self.secret.clone()),
     )
+  }
+}
+
+impl MFKDF2DerivedKey {
+  /// Derive an internal key for deriving separate keys for parameters, secret, and integrity
+  /// using the policy salt and secret.
+  fn derive_internal_key(&self) -> MFKDF2Result<Key> {
+    let salt = general_purpose::STANDARD.decode(&self.policy.salt)?;
+
+    let mut kek = [0u8; 32];
+    Argon2::new(
+      argon2::Algorithm::Argon2id,
+      argon2::Version::default(),
+      argon2::Params::new(
+        argon2::Params::DEFAULT_M_COST + self.policy.memory,
+        argon2::Params::DEFAULT_T_COST + self.policy.time,
+        1,
+        Some(32),
+      )?,
+    )
+    .hash_password_into(&self.secret, &salt, &mut kek)?;
+
+    let policy_key = general_purpose::STANDARD.decode(&self.policy.key)?;
+    let key = decrypt(policy_key, &kek);
+    key.try_into()
   }
 }

--- a/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/mod.rs
@@ -68,6 +68,24 @@ impl std::fmt::Display for MFKDF2DerivedKey {
   }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for MFKDF2DerivedKey {
+  fn zeroize(&mut self) {
+    self.key.zeroize();
+    self.secret.zeroize();
+    self.shares.zeroize();
+    self.policy.zeroize();
+  }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for MFKDF2DerivedKey {
+  fn drop(&mut self) {
+    use zeroize::Zeroize;
+    self.zeroize();
+  }
+}
+
 impl MFKDF2DerivedKey {
   /// Derive an internal key for deriving separate keys for parameters, secret, and integrity
   /// using the policy salt and secret.

--- a/mfkdf2/src/definitions/mfkdf_derived_key/reconstitution.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/reconstitution.rs
@@ -6,6 +6,9 @@
 //! Consider a key derived from a password, a TOTP factor, and a UUID factor. Using threshold
 //! recovery, the user can derive the key with only a subset of factors inside the policy.
 //!
+//! **Note**: MFKDF2 provides no mechanism to invalidate old policies. When threshold is increased
+//! via reconstitution, old policies can still be used to derive keys.
+//!
 //! ```rust
 //! # use std::collections::HashMap;
 //! # use uuid::Uuid;

--- a/mfkdf2/src/definitions/mfkdf_derived_key/strengthening.rs
+++ b/mfkdf2/src/definitions/mfkdf_derived_key/strengthening.rs
@@ -93,6 +93,10 @@ impl MFKDF2DerivedKey {
   /// [`crate::error::MFKDF2Error::PolicyIntegrityCheckFailed`] if an attacker attempts to
   /// weaken or roll back the policy, as that invalidates the integrity MAC.
   pub fn strengthen(&mut self, time: u32, memory: u32) -> MFKDF2Result<()> {
+    // derive internal key
+    let internal_key = self.derive_internal_key()?;
+
+    // update policy time and memory
     self.policy.time = time;
     self.policy.memory = memory;
 
@@ -112,7 +116,7 @@ impl MFKDF2DerivedKey {
     )
     .hash_password_into(&self.secret, &salt, &mut kek)?;
 
-    let policy_key = encrypt(self.key.as_ref(), &kek);
+    let policy_key = encrypt(&internal_key, &kek);
     self.policy.key = general_purpose::STANDARD.encode(policy_key);
     Ok(())
   }

--- a/mfkdf2/src/definitions/uniffi_types.rs
+++ b/mfkdf2/src/definitions/uniffi_types.rs
@@ -15,7 +15,7 @@ uniffi::custom_type!(HmacSha1Response, Vec<u8>, {
     if v.len() == 20 {
       let mut arr = [0u8; 20];
       arr.copy_from_slice(&v);
-      Ok(HmacSha1Response(arr))
+      Ok(arr.into())
     } else {
       Err(uniffi::deps::anyhow::anyhow!(
         "Expected Vec<u8> of length 20, got {}",

--- a/mfkdf2/src/definitions/uniffi_types.rs
+++ b/mfkdf2/src/definitions/uniffi_types.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 uniffi::custom_type!(HmacSha1Response, Vec<u8>, {
-  lower: |r| r.0.to_vec(),
+  lower: |r| r.to_vec(),
   try_lift: |v: Vec<u8>| {
     if v.len() == 20 {
       let mut arr = [0u8; 20];

--- a/mfkdf2/src/derive/factors/hmacsha1.rs
+++ b/mfkdf2/src/derive/factors/hmacsha1.rs
@@ -21,8 +21,6 @@ impl FactorDerive for HmacSha1 {
 
   /// Includes the public parameters for in factor state and decrypts the secret material.
   fn include_params(&mut self, params: Self::Params) -> MFKDF2Result<()> {
-    self.params = Some(serde_json::to_string(&params).unwrap());
-
     let response = self.response.as_ref().unwrap();
     let mut padded_key = [0u8; 32];
     padded_key[..response.0.len()].copy_from_slice(&response.0);
@@ -130,12 +128,11 @@ impl FactorDerive for HmacSha1 {
 /// assert_eq!(derived_key.key, setup_key.key);
 /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
 /// ```
-pub fn hmacsha1(response: HmacSha1Response) -> MFKDF2Result<MFKDF2Factor> {
+pub fn hmacsha1(response: impl Into<HmacSha1Response>) -> MFKDF2Result<MFKDF2Factor> {
   Ok(MFKDF2Factor {
     id:          None,
     factor_type: FactorType::HmacSha1(HmacSha1 {
-      response:      Some(response),
-      params:        None,
+      response:      Some(response.into()),
       padded_secret: [0u8; 32].to_vec(),
     }),
     entropy:     None,
@@ -180,7 +177,7 @@ mod tests {
       .collect::<Vec<u8>>();
     let response = crate::crypto::hmacsha1(&secret, &challenge);
 
-    let result = hmacsha1(response.into());
+    let result = hmacsha1(response);
     assert!(result.is_ok());
     result.unwrap().factor_type
   }

--- a/mfkdf2/src/derive/factors/hmacsha1.rs
+++ b/mfkdf2/src/derive/factors/hmacsha1.rs
@@ -23,7 +23,7 @@ impl FactorDerive for HmacSha1 {
   fn include_params(&mut self, params: Self::Params) -> MFKDF2Result<()> {
     let response = self.response.as_ref().unwrap();
     let mut padded_key = [0u8; 32];
-    padded_key[..response.0.len()].copy_from_slice(&response.0);
+    padded_key[..response.len()].copy_from_slice(&response);
 
     let pad = hex::decode(
       params
@@ -117,7 +117,7 @@ impl FactorDerive for HmacSha1 {
 ///   .into();
 ///
 /// // Build the derive‑time HMAC witness and run KeyDerive
-/// let derive_factor = derive::factors::hmacsha1(response.into())?;
+/// let derive_factor = derive::factors::hmacsha1(response)?;
 /// let derived_key = derive::key(
 ///   &setup_key.policy,
 ///   HashMap::from([("hmacsha1".to_string(), derive_factor)]),

--- a/mfkdf2/src/derive/factors/hotp.rs
+++ b/mfkdf2/src/derive/factors/hotp.rs
@@ -42,6 +42,7 @@ impl FactorDerive for HOTP {
 
     // Decrypt the secret using the factor key
     let pad = base64::prelude::BASE64_STANDARD.decode(&params.pad)?;
+    #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
     let mut padded_secret = decrypt(pad, key);
 
     // Generate HOTP code with incremented counter

--- a/mfkdf2/src/derive/factors/hotp.rs
+++ b/mfkdf2/src/derive/factors/hotp.rs
@@ -42,7 +42,7 @@ impl FactorDerive for HOTP {
 
     // Decrypt the secret using the factor key
     let pad = base64::prelude::BASE64_STANDARD.decode(&params.pad)?;
-    let padded_secret = decrypt(pad, &key.0);
+    let mut padded_secret = decrypt(pad, key);
 
     // Generate HOTP code with incremented counter
     let counter = params.counter + 1;
@@ -52,6 +52,12 @@ impl FactorDerive for HOTP {
     // Calculate new offset
     let new_offset =
       mod_positive(i64::from(self.target) - i64::from(generated_code), 10_i64.pow(params.digits));
+
+    #[cfg(feature = "zeroize")]
+    {
+      use zeroize::Zeroize;
+      padded_secret.zeroize();
+    }
 
     Ok(json!({
       "hash": params.hash.to_string(),

--- a/mfkdf2/src/derive/factors/ooba.rs
+++ b/mfkdf2/src/derive/factors/ooba.rs
@@ -27,14 +27,14 @@ impl FactorDerive for Ooba {
 
   /// Includes the public parameters for in factor state and decrypts the secret material from
   /// public parameters.
-  fn include_params(&mut self, params: Self::Params) -> MFKDF2Result<()> {
+  fn include_params(&mut self, mut params: Self::Params) -> MFKDF2Result<()> {
     let pad_b64 =
       params["pad"].as_str().ok_or(MFKDF2Error::MissingDeriveParams("pad".to_string()))?;
     let pad = general_purpose::STANDARD
       .decode(pad_b64)
       .map_err(|_| MFKDF2Error::InvalidDeriveParams("pad".to_string()))?;
 
-    let config = params["params"].clone();
+    let config = params["params"].take();
     if !config.is_object() {
       return Err(MFKDF2Error::InvalidDeriveParams("params".to_string()));
     }
@@ -48,7 +48,7 @@ impl FactorDerive for Ooba {
     self.length = params["length"]
       .as_u64()
       .ok_or(MFKDF2Error::MissingDeriveParams("length".to_string()))? as u8;
-    let jwk = serde_json::from_value::<jsonwebtoken::jwk::Jwk>(params["key"].clone())
+    let jwk = serde_json::from_value::<jsonwebtoken::jwk::Jwk>(params["key"].take())
       .map_err(|_| MFKDF2Error::InvalidDeriveParams("key".to_string()))?;
     self.jwk = Some(jwk);
 

--- a/mfkdf2/src/derive/factors/passkey.rs
+++ b/mfkdf2/src/derive/factors/passkey.rs
@@ -8,7 +8,7 @@ use crate::{
   definitions::{FactorType, MFKDF2Factor},
   derive::FactorDerive,
   error::MFKDF2Result,
-  setup::factors::passkey::Passkey,
+  setup::factors::passkey::{Passkey, PasskeySecret},
 };
 
 impl FactorDerive for Passkey {
@@ -65,10 +65,10 @@ impl FactorDerive for Passkey {
 /// assert_eq!(derived_key.key, setup_key.key);
 /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
 /// ```
-pub fn passkey(secret: [u8; 32]) -> MFKDF2Result<MFKDF2Factor> {
+pub fn passkey(secret: impl Into<PasskeySecret>) -> MFKDF2Result<MFKDF2Factor> {
   Ok(MFKDF2Factor {
     id:          Some("passkey".to_string()),
-    factor_type: FactorType::Passkey(Passkey { secret: secret.to_vec() }),
+    factor_type: FactorType::Passkey(Passkey { secret: secret.into() }),
     entropy:     None,
   })
 }
@@ -79,6 +79,7 @@ async fn derive_passkey(secret: Vec<u8>) -> MFKDF2Result<MFKDF2Factor> {
   if secret.len() != 32 {
     return Err(crate::error::MFKDF2Error::InvalidSecretLength("passkey".to_string()));
   }
+  let secret: PasskeySecret = secret.try_into().unwrap();
 
-  passkey(secret.try_into().unwrap())
+  passkey(secret)
 }

--- a/mfkdf2/src/derive/factors/persisted.rs
+++ b/mfkdf2/src/derive/factors/persisted.rs
@@ -11,8 +11,9 @@ use crate::{
 };
 
 /// Persisted share factor state.
-#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
 pub struct Persisted {
   /// Base-64 encoded Shamir share to recover the master secret.
   pub share: Vec<u8>,

--- a/mfkdf2/src/derive/factors/totp.rs
+++ b/mfkdf2/src/derive/factors/totp.rs
@@ -102,6 +102,7 @@ impl FactorDerive for TOTP {
     let params: TOTPParams = serde_json::from_value(self.params.clone())?;
 
     let pad = base64::prelude::BASE64_STANDARD.decode(params.pad)?;
+    #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
     let mut padded_secret = decrypt(pad.clone(), key.as_ref());
 
     let time = params.start;

--- a/mfkdf2/src/derive/key.rs
+++ b/mfkdf2/src/derive/key.rs
@@ -320,7 +320,7 @@ pub fn key(
 
   let sss = SecretSharing(policy.threshold);
   let secret = sss.recover(&shares_vec).map_err(|_| MFKDF2Error::ShareRecovery)?;
-  let mut secret_arr: [u8; 32] = secret.try_into().map_err(|_| MFKDF2Error::TryFromVec)?;
+  let mut secret_arr: [u8; 32] = secret[..32].try_into().map_err(|_| MFKDF2Error::TryFromVec)?;
   let salt_bytes = general_purpose::STANDARD.decode(&policy.salt)?;
 
   // Generate key

--- a/mfkdf2/src/derive/key.rs
+++ b/mfkdf2/src/derive/key.rs
@@ -320,6 +320,7 @@ pub fn key(
 
   let sss = SecretSharing(policy.threshold);
   let secret = sss.recover(&shares_vec).map_err(|_| MFKDF2Error::ShareRecovery)?;
+  #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
   let mut secret_arr: [u8; 32] = secret[..32].try_into().map_err(|_| MFKDF2Error::TryFromVec)?;
   let salt_bytes = general_purpose::STANDARD.decode(&policy.salt)?;
 
@@ -352,6 +353,7 @@ pub fn key(
   let internal_key = decrypt(policy_key_bytes, &kek);
 
   // Perform integrity check
+  #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
   let mut integrity_key =
     hkdf_sha256_with_info(&internal_key, &salt_bytes, "mfkdf2:integrity".as_bytes());
   if verify {

--- a/mfkdf2/src/derive/key.rs
+++ b/mfkdf2/src/derive/key.rs
@@ -590,7 +590,7 @@ mod tests {
       panic!()
     };
     let response = crate::crypto::hmacsha1(secret, &challenge);
-    let mut derive_hmac_factor = derive_hmacsha1(response.into()).unwrap();
+    let mut derive_hmac_factor = derive_hmacsha1(response).unwrap();
     derive_hmac_factor.id = Some("hmac".to_string());
     derive_factors_map.insert("hmac".to_string(), derive_hmac_factor);
 
@@ -822,7 +822,7 @@ mod tests {
     let challenge = hex::decode(params["challenge"].as_str().unwrap()).unwrap();
     let secret = &hmac_setup.padded_secret[..20];
     let response = crate::crypto::hmacsha1(secret, &challenge);
-    let mut derive_hmac_factor = derive_hmacsha1(response.into()).unwrap();
+    let mut derive_hmac_factor = derive_hmacsha1(response).unwrap();
     derive_hmac_factor.id = Some("hmac".to_string());
     derive_factors_map.insert("hmac".to_string(), derive_hmac_factor);
 

--- a/mfkdf2/src/error.rs
+++ b/mfkdf2/src/error.rs
@@ -113,4 +113,10 @@ pub enum MFKDF2Error {
 
   #[error(transparent)]
   Regex(#[from] rand_regex::Error),
+
+  #[error(transparent)]
+  Encrypt(#[from] cipher::inout::PadError),
+
+  #[error(transparent)]
+  Decrypt(#[from] cipher::inout::block_padding::UnpadError),
 }

--- a/mfkdf2/src/integrity.rs
+++ b/mfkdf2/src/integrity.rs
@@ -62,6 +62,7 @@ pub fn extract_factor_core(factor: &PolicyFactor) -> [u8; 32] {
   hasher.update(factor.pad.as_bytes());
   hasher.update(factor.salt.as_bytes());
   hasher.update(factor.secret.as_bytes());
+  hasher.update(factor.hint.as_ref().unwrap_or(&String::new()).as_bytes());
 
   hasher.finalize().into()
 }

--- a/mfkdf2/src/otpauth.rs
+++ b/mfkdf2/src/otpauth.rs
@@ -93,6 +93,19 @@ pub struct OtpAuthUrlOptions {
   pub algorithm: Option<HashAlgorithm>,
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for OtpAuthUrlOptions {
+  fn zeroize(&mut self) { self.secret.zeroize(); }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for OtpAuthUrlOptions {
+  fn drop(&mut self) {
+    use zeroize::Zeroize;
+    self.zeroize();
+  }
+}
+
 /// Convert an input secret (with a declared encoding) into Base32 (no padding),
 /// removing spaces and normalizing case where needed.
 fn secret_to_base32_no_pad(secret: &str, enc: &Encoding) -> Result<String, String> {

--- a/mfkdf2/src/policy/mod.rs
+++ b/mfkdf2/src/policy/mod.rs
@@ -55,14 +55,6 @@ impl zeroize::Zeroize for PolicyFactor {
   }
 }
 
-#[cfg(feature = "zeroize")]
-impl Drop for PolicyFactor {
-  fn drop(&mut self) {
-    use zeroize::Zeroize;
-    self.zeroize();
-  }
-}
-
 /// MFKDF policy is a set of all allowable factor combinations that can be used to derive the final
 /// key. MFKDF instance after i-th derivation consists of public construction parameters (threshold,
 /// salt, etc.), per-factor public parameters (encrypted shares, secret), and factor public state
@@ -105,17 +97,6 @@ impl zeroize::Zeroize for Policy {
     self.factors.zeroize();
     self.hmac.zeroize();
     self.key.zeroize();
-  }
-}
-
-#[cfg(feature = "zeroize")]
-impl Drop for Policy {
-  fn drop(&mut self) {
-    use zeroize::Zeroize;
-    self.salt.zeroize();
-    self.hmac.zeroize();
-    self.key.zeroize();
-    self.factors.zeroize();
   }
 }
 

--- a/mfkdf2/src/policy/mod.rs
+++ b/mfkdf2/src/policy/mod.rs
@@ -47,6 +47,22 @@ pub struct PolicyFactor {
   pub hint:   Option<String>,
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for PolicyFactor {
+  fn zeroize(&mut self) {
+    self.salt.zeroize();
+    self.secret.zeroize();
+  }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for PolicyFactor {
+  fn drop(&mut self) {
+    use zeroize::Zeroize;
+    self.zeroize();
+  }
+}
+
 /// MFKDF policy is a set of all allowable factor combinations that can be used to derive the final
 /// key. MFKDF instance after i-th derivation consists of public construction parameters (threshold,
 /// salt, etc.), per-factor public parameters (encrypted shares, secret), and factor public state
@@ -80,6 +96,27 @@ pub struct Policy {
   /// Base-64 encoded policy key encrypted using KEK (key encapsulation key).
   /// It is used to derive other keys (params, integrity, etc.) in the policy.
   pub key:       String,
+}
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for Policy {
+  fn zeroize(&mut self) {
+    self.salt.zeroize();
+    self.factors.zeroize();
+    self.hmac.zeroize();
+    self.key.zeroize();
+  }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for Policy {
+  fn drop(&mut self) {
+    use zeroize::Zeroize;
+    self.salt.zeroize();
+    self.hmac.zeroize();
+    self.key.zeroize();
+    self.factors.zeroize();
+  }
 }
 
 impl Policy {

--- a/mfkdf2/src/policy/tests.rs
+++ b/mfkdf2/src/policy/tests.rs
@@ -135,7 +135,7 @@ fn create_policy_basic_1() -> policy::Policy {
   let or2 = or(h1, t1).unwrap();
   let policy_factor = and(or1, or2).unwrap();
 
-  policy::setup::setup(policy_factor, PolicySetupOptions::default()).unwrap().policy
+  policy::setup::setup(policy_factor, PolicySetupOptions::default()).unwrap().policy.clone()
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn create_policy_basic_2() -> policy::Policy {
   let and2 = and(h1, t1).unwrap();
   let policy_factor = or(and1, and2).unwrap();
 
-  policy::setup::setup(policy_factor, PolicySetupOptions::default()).unwrap().policy
+  policy::setup::setup(policy_factor, PolicySetupOptions::default()).unwrap().policy.clone()
 }
 
 #[test]

--- a/mfkdf2/src/setup/factors/hmacsha1.rs
+++ b/mfkdf2/src/setup/factors/hmacsha1.rs
@@ -33,7 +33,6 @@ use crate::{
 ///   and the token agree on the same `kₜ`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
-#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct HmacSha1Options {
   /// Optional application-defined identifier for the factor. Defaults to `"hmacsha1"`. If
   /// provided, it must be non-empty.
@@ -56,7 +55,7 @@ pub(crate) type HmacSha1Response = ByteArray<20>;
 /// that the derive side can use to confirm it has the same secret.
 #[cfg_attr(feature = "bindings", derive(uniffi::Record))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
 pub struct HmacSha1 {
   /// HMAC‑SHA1 response
   pub response:      Option<HmacSha1Response>,
@@ -82,6 +81,12 @@ impl FactorSetup for HmacSha1 {
     let mut padded_key = [0u8; 32];
     padded_key[..response.len()].copy_from_slice(&response);
     let pad = encrypt(&self.padded_secret, &padded_key);
+
+    #[cfg(feature = "zeroize")]
+    {
+      use zeroize::Zeroize;
+      padded_key.zeroize();
+    }
 
     Ok(json!({
       "challenge": hex::encode(challenge),
@@ -148,13 +153,12 @@ pub fn hmacsha1(mut options: HmacSha1Options) -> MFKDF2Result<MFKDF2Factor> {
   }
   let id = options.id.take().unwrap_or("hmacsha1".to_string());
 
-  let secret = if let Some(secret) = options.secret.take() {
-    secret
-  } else {
+  // consume the secret from options and generate a random one if none is provided
+  let secret = options.secret.take().unwrap_or_else(|| {
     let mut secret = [0u8; 20];
     rng::fill_bytes(&mut secret);
     secret.to_vec()
-  };
+  });
   if secret.len() != 20 {
     return Err(crate::error::MFKDF2Error::InvalidSecretLength(id));
   }

--- a/mfkdf2/src/setup/factors/password.rs
+++ b/mfkdf2/src/setup/factors/password.rs
@@ -14,8 +14,9 @@ use crate::{
 };
 
 /// Password factor state
-#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "bindings", derive(uniffi::Record))]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
 pub struct Password {
   /// User-chosen password string.
   pub password: String,
@@ -89,7 +90,7 @@ pub fn password(
     return Err(crate::error::MFKDF2Error::MissingFactorId);
   }
 
-  let password = std::convert::Into::<String>::into(password);
+  let password = password.into();
   if password.is_empty() {
     return Err(MFKDF2Error::PasswordEmpty);
   }

--- a/mfkdf2/src/setup/factors/stack.rs
+++ b/mfkdf2/src/setup/factors/stack.rs
@@ -30,17 +30,15 @@ pub struct StackOptions {
 }
 
 impl From<StackOptions> for MFKDF2Options {
-  fn from(value: StackOptions) -> Self {
-    let StackOptions { id, threshold, salt } = value;
-
+  fn from(mut value: StackOptions) -> Self {
     MFKDF2Options {
-      id,
-      threshold,
-      salt,
-      stack: Some(true),
+      id:        value.id.take(),
+      threshold: value.threshold.take(),
+      salt:      value.salt.take(),
+      stack:     Some(true),
       integrity: Some(false),
-      time: None,
-      memory: None,
+      time:      None,
+      memory:    None,
     }
   }
 }
@@ -56,6 +54,14 @@ pub struct Stack {
   pub factors: HashMap<String, MFKDF2Factor>,
   /// Final Derived key.
   pub key:     MFKDF2DerivedKey,
+}
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for Stack {
+  fn zeroize(&mut self) {
+    self.factors.values_mut().for_each(|factor| factor.zeroize());
+    self.key.zeroize();
+  }
 }
 
 impl FactorMetadata for Stack {

--- a/mfkdf2/src/setup/factors/uuid.rs
+++ b/mfkdf2/src/setup/factors/uuid.rs
@@ -36,6 +36,11 @@ pub struct UUIDFactor {
   pub uuid: Uuid,
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for UUIDFactor {
+  fn zeroize(&mut self) {}
+}
+
 impl FactorMetadata for UUIDFactor {
   fn kind(&self) -> String { "uuid".to_string() }
 
@@ -71,7 +76,7 @@ impl FactorSetup for UUIDFactor {
 /// assert_eq!(factor.id.as_deref(), Some("uuid"));
 /// # Ok::<(), mfkdf2::error::MFKDF2Error>(())
 /// ```
-pub fn uuid(options: UUIDOptions) -> MFKDF2Result<MFKDF2Factor> {
+pub fn uuid(mut options: UUIDOptions) -> MFKDF2Result<MFKDF2Factor> {
   // Validation
   if let Some(ref id) = options.id
     && id.is_empty()
@@ -79,7 +84,7 @@ pub fn uuid(options: UUIDOptions) -> MFKDF2Result<MFKDF2Factor> {
     return Err(crate::error::MFKDF2Error::MissingFactorId);
   }
 
-  let uuid = options.uuid.unwrap_or(Uuid::new_v4());
+  let uuid = options.uuid.take().unwrap_or(Uuid::new_v4());
 
   Ok(MFKDF2Factor {
     id:          Some(options.id.unwrap_or("uuid".to_string())),

--- a/mfkdf2/src/setup/key.rs
+++ b/mfkdf2/src/setup/key.rs
@@ -4,6 +4,8 @@
 //!
 //! Master secret `M` is split into Shamir shares `Sᵢ` over the configured polynomial, and encrypted
 //! to produce encrypted shares `Cᵢ` which is then stored in the [`Policy`].
+
+#![cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
 // TODO (autoparallel): If we use `no-std`, then this use of `HashSet` will need to be
 // replaced.
 use std::collections::{HashMap, HashSet};

--- a/mfkdf2/src/setup/key.rs
+++ b/mfkdf2/src/setup/key.rs
@@ -217,8 +217,9 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   let mut secret: [u8; 32] = [0u8; 32];
   crate::rng::fill_bytes(&mut secret);
 
-  let mut key = [0u8; 32];
-  crate::rng::fill_bytes(&mut key);
+  // Create an internal key for deriving separate keys for parameters, secret, and integrity
+  let mut internal_key = [0u8; 32];
+  crate::rng::fill_bytes(&mut internal_key);
 
   // Generate key
   let mut kek = [0u8; 32];
@@ -241,7 +242,7 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   }
 
   // policy key
-  let policy_key = encrypt(&key, &kek);
+  let policy_key = encrypt(&internal_key, &kek);
 
   // Split secret into Shamir shares
   let dealer =
@@ -273,13 +274,13 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
 
     // Generate factor key
     let params_key =
-      hkdf_sha256_with_info(&key, &salt, format!("mfkdf2:factor:params:{id}").as_bytes());
+      hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:params:{id}").as_bytes());
     let params = factor.factor_type.setup().params(params_key.into())?;
 
     outputs.insert(id.clone(), factor.factor_type.output());
 
     let secret_key =
-      hkdf_sha256_with_info(&key, &salt, format!("mfkdf2:factor:secret:{id}").as_bytes());
+      hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:secret:{id}").as_bytes());
     let factor_secret = encrypt(&stretched, &secret_key);
 
     // Record entropy statistics (in bits) for this factor.
@@ -313,7 +314,7 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   // Derive an integrity key specific to the policy and compute a policy HMAC
   if options.integrity.unwrap_or(true) {
     let integrity_data = policy.extract();
-    let integrity_key = hkdf_sha256_with_info(&key, &salt, "mfkdf2:integrity".as_bytes());
+    let integrity_key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:integrity".as_bytes());
     let digest = hmacsha256(&integrity_key, &integrity_data);
     policy.hmac = general_purpose::STANDARD.encode(digest);
   }
@@ -328,9 +329,14 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
   let entropy_theoretical = theoretical_sum.min(256);
   let entropy_real = real_sum.min(256.0);
 
+  // derive a dedicated final key to ensure domain separation between internal and external keys
+  if !options.stack.unwrap_or(false) {
+    internal_key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
+  }
+
   Ok(MFKDF2DerivedKey {
     policy,
-    key: key.into(),
+    key: internal_key.into(),
     secret: secret.to_vec(),
     shares,
     outputs,
@@ -464,7 +470,8 @@ mod tests {
     .unwrap();
 
     let policy_key = general_purpose::STANDARD.decode(derived_key.policy.key.clone()).unwrap();
-    let key = decrypt(policy_key, &kek);
+    let internal_key = decrypt(policy_key, &kek);
+    let key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
 
     assert_eq!(derived_key.policy.id, options.id.unwrap());
     assert_eq!(derived_key.policy.threshold as usize, factors.len());
@@ -472,13 +479,13 @@ mod tests {
     assert_eq!(derived_key.policy.time, options.time.unwrap());
     assert_eq!(derived_key.policy.memory, options.memory.unwrap());
 
-    assert_eq!(derived_key.key, key.clone().try_into().unwrap());
+    assert_eq!(derived_key.key, key.into());
 
     // verify factor secret is encrypted with key
     let mut shares = Vec::new();
     for factor in &derived_key.policy.factors {
       let secret_key = hkdf_sha256_with_info(
-        &key,
+        &internal_key,
         &general_purpose::STANDARD.decode(factor.salt.clone()).unwrap(),
         format!("mfkdf2:factor:secret:{}", &factor.id).as_bytes(),
       );
@@ -533,8 +540,9 @@ mod tests {
     .unwrap();
 
     let policy_key = general_purpose::STANDARD.decode(derived_key.policy.key.clone()).unwrap();
-    let key = decrypt(policy_key, &kek);
-    assert_eq!(derived_key.key, key.clone().try_into().unwrap());
+    let internal_key = decrypt(policy_key, &kek);
+    let key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
+    assert_eq!(derived_key.key, key.into());
 
     let shares_to_recover: Vec<Vec<u8>> =
       derived_key.shares.iter().take(threshold as usize).cloned().collect();

--- a/mfkdf2/src/setup/key.rs
+++ b/mfkdf2/src/setup/key.rs
@@ -268,18 +268,18 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
     crate::rng::fill_bytes(&mut salt);
 
     // HKDF stretch & AES-encrypt share
-    let stretched =
+    let mut stretched =
       hkdf_sha256_with_info(&factor.data(), &salt, format!("mfkdf2:factor:pad:{id}").as_bytes());
     let pad = encrypt(share, &stretched);
 
     // Generate factor key
-    let params_key =
+    let mut params_key =
       hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:params:{id}").as_bytes());
     let params = factor.factor_type.setup().params(params_key.into())?;
 
     outputs.insert(id.clone(), factor.factor_type.output());
 
-    let secret_key =
+    let mut secret_key =
       hkdf_sha256_with_info(&internal_key, &salt, format!("mfkdf2:factor:secret:{id}").as_bytes());
     let factor_secret = encrypt(&stretched, &secret_key);
 
@@ -297,13 +297,21 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
       params,
       hint: None,
     });
+
+    #[cfg(feature = "zeroize")]
+    {
+      use zeroize::Zeroize;
+      stretched.zeroize();
+      params_key.zeroize();
+      secret_key.zeroize();
+    }
   }
 
   let mut policy = Policy {
     schema: "https://mfkdf.com/schema/v2.0.0/policy.json".to_string(),
     id: policy_id,
     threshold,
-    salt: general_purpose::STANDARD.encode(&salt),
+    salt: general_purpose::STANDARD.encode(salt.as_ref()),
     factors: policy_factors,
     hmac: String::new(),
     time,
@@ -334,17 +342,27 @@ pub fn key(factors: &[MFKDF2Factor], options: MFKDF2Options) -> MFKDF2Result<MFK
     internal_key = hkdf_sha256_with_info(&internal_key, &salt, "mfkdf2:key:final".as_bytes());
   }
 
-  Ok(MFKDF2DerivedKey {
+  let result = MFKDF2DerivedKey {
     policy,
     key: internal_key.into(),
-    secret: secret.to_vec(),
+    secret: secret.into(),
     shares,
     outputs,
     entropy: crate::definitions::MFKDF2Entropy {
       real:        entropy_real,
       theoretical: entropy_theoretical,
     },
-  })
+  };
+
+  #[cfg(feature = "zeroize")]
+  {
+    use zeroize::Zeroize;
+    secret.zeroize();
+    internal_key.zeroize();
+    kek.zeroize();
+  }
+
+  Ok(result)
 }
 
 #[cfg(feature = "bindings")]
@@ -475,7 +493,10 @@ mod tests {
 
     assert_eq!(derived_key.policy.id, options.id.unwrap());
     assert_eq!(derived_key.policy.threshold as usize, factors.len());
-    assert_eq!(derived_key.policy.salt, general_purpose::STANDARD.encode(options.salt.unwrap()));
+    assert_eq!(
+      derived_key.policy.salt,
+      general_purpose::STANDARD.encode(options.salt.unwrap().as_ref())
+    );
     assert_eq!(derived_key.policy.time, options.time.unwrap());
     assert_eq!(derived_key.policy.memory, options.memory.unwrap());
 
@@ -490,7 +511,7 @@ mod tests {
         format!("mfkdf2:factor:secret:{}", &factor.id).as_bytes(),
       );
       let factor_secret = general_purpose::STANDARD.decode(factor.secret.clone()).unwrap();
-      let stretched = decrypt(factor_secret, &secret_key).try_into().unwrap();
+      let stretched: [u8; 32] = decrypt(factor_secret, &secret_key).try_into().unwrap();
 
       let pad = general_purpose::STANDARD.decode(factor.pad.clone()).unwrap();
       let factor_share = decrypt(pad, &stretched);
@@ -505,7 +526,7 @@ mod tests {
     let sss = SecretSharing(derived_key.policy.threshold);
     let secret = sss.recover(&shares_vec).unwrap();
 
-    assert_eq!(secret[..32], derived_key.secret);
+    assert_eq!(&secret[..32], derived_key.secret.as_ref());
   }
 
   #[rstest]
@@ -553,7 +574,7 @@ mod tests {
     let sss = SecretSharing(threshold);
     let recovered_secret = sss.recover(&shares_vec).unwrap();
 
-    assert_eq!(recovered_secret[..32], derived_key.secret);
+    assert_eq!(&recovered_secret[..32], derived_key.secret.as_ref());
   }
 
   #[rstest]

--- a/mfkdf2/tests/common/mod.rs
+++ b/mfkdf2/tests/common/mod.rs
@@ -262,7 +262,7 @@ pub fn create_derive_factor(
         .finalize()
         .into_bytes()
         .into();
-      ("hmacsha1_1".to_string(), mfkdf2::derive::factors::hmacsha1(response.into()).unwrap())
+      ("hmacsha1_1".to_string(), mfkdf2::derive::factors::hmacsha1(response).unwrap())
     },
     "question" =>
       ("question_1".to_string(), mfkdf2::derive::factors::question("my secret answer").unwrap()),

--- a/mfkdf2/tests/integration.rs
+++ b/mfkdf2/tests/integration.rs
@@ -139,8 +139,7 @@ fn key_derive_hmacsha1() -> Result<(), mfkdf2::error::MFKDF2Error> {
     .into_bytes()
     .into();
 
-  let factor =
-    ("hmacsha1_1".to_string(), mfkdf2::derive::factors::hmacsha1(response.into()).unwrap());
+  let factor = ("hmacsha1_1".to_string(), mfkdf2::derive::factors::hmacsha1(response).unwrap());
   let factors = HashMap::from([factor]);
 
   let derived_key = mfkdf2::derive::key(&key.policy, factors, true, false)?;
@@ -357,7 +356,7 @@ fn key_derivation_combinations(
         combo, i
       );
 
-      policy_for_run = derived_key.policy;
+      policy_for_run = derived_key.policy.clone();
     }
   }
 

--- a/mfkdf2/tests/integrity.rs
+++ b/mfkdf2/tests/integrity.rs
@@ -68,7 +68,7 @@ fn integrity_enabled_clean_liveness() {
   // integrity enabled; clean policy should derive and remain stable across runs
   let setup_derived_key = make_policy(&["password", "hotp", "totp", "uuid"], 4, true);
 
-  let policy = setup_derived_key.policy;
+  let policy = setup_derived_key.policy.clone();
 
   let d1 = derive_once(&policy, &["password", "hotp", "totp", "uuid"], true);
   let d2 = derive_once(&d1.policy, &["password", "hotp", "totp", "uuid"], true);
@@ -81,7 +81,7 @@ fn integrity_enabled_clean_liveness() {
 fn integrity_enabled_rejects_policy_id_tamper() {
   let setup_derived_key = make_policy(&["password", "uuid"], 2, true);
 
-  let mut policy = setup_derived_key.policy;
+  let mut policy = setup_derived_key.policy.clone();
 
   policy.id = "tampered".to_string();
 
@@ -96,7 +96,7 @@ fn integrity_enabled_rejects_policy_id_tamper() {
 fn integrity_enabled_rejects_threshold_tamper() {
   let setup_derived_key = make_policy(&["password", "question"], 2, true);
 
-  let mut policy = setup_derived_key.policy;
+  let mut policy = setup_derived_key.policy.clone();
 
   // Tamper threshold
   policy.threshold += 1;
@@ -112,7 +112,7 @@ fn integrity_enabled_rejects_threshold_tamper() {
 fn integrity_enabled_rejects_salt_tamper() {
   let setup_derived_key = make_policy(&["password", "totp"], 2, true);
 
-  let mut policy = setup_derived_key.policy;
+  let mut policy = setup_derived_key.policy.clone();
 
   // Tamper salt (base64)
   policy.salt = "Ny9+L9LQHOKh1x3Acqy7pMb9JaEIfNfxU/TsDON+Ht4=".to_string();
@@ -128,7 +128,7 @@ fn integrity_enabled_rejects_salt_tamper() {
 fn integrity_enabled_rejects_factor_id_tamper() {
   let setup_derived_key = make_policy(&["password", "uuid"], 2, true);
 
-  let mut policy = setup_derived_key.policy;
+  let mut policy = setup_derived_key.policy.clone();
 
   // Tamper a factor id (password)
   if let Some(f) = policy.factors.iter_mut().find(|f| f.id == "password_1") {
@@ -156,7 +156,7 @@ fn integrity_enabled_rejects_derived_policy_tamper() {
   // Start clean with integrity=true
   let setup_derived_key = make_policy(&["password", "hotp", "totp", "uuid"], 4, true);
 
-  let policy = setup_derived_key.policy;
+  let policy = setup_derived_key.policy.clone();
 
   // First derive succeeds
   let derived = derive_once(&policy, &["password", "hotp", "uuid", "totp"], true);

--- a/mfkdf2/tests/stack.rs
+++ b/mfkdf2/tests/stack.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use hmac::{Hmac, Mac};
-use mfkdf2::{policy::Policy, setup::factors::hmacsha1::HmacSha1Response};
+use mfkdf2::policy::Policy;
 use sha1::Sha1;
 
 const HMACSHA1_SECRET: [u8; 20] = [
@@ -122,10 +122,7 @@ fn stack_derive() {
           )
           .unwrap(),
         ),
-        (
-          "hmacsha1_1".to_string(),
-          mfkdf2::derive::factors::hmacsha1(HmacSha1Response::from(response)).unwrap(),
-        ),
+        ("hmacsha1_1".to_string(), mfkdf2::derive::factors::hmacsha1(response).unwrap()),
       ]))
       .unwrap(),
     )]),


### PR DESCRIPTION
closes #44 

Changes:
- zeroize for all structs with sensitive material
- `zeroize` feature. turned on as default feature.
- manual zeroize sensitive keys/secrets in methods.
  - Uniffi doesn't allow `Drop` due to multiple copies of same buffer in FFI boundary conversions.
- Replace factor specific secret, key types with compile-time checked `ByteArray` removing `Vec<u8>`.