### PR TITLE
devcontainer for ease of development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "MFKDF2-${localEnv:USERNAME}",
+	"image": "mcr.microsoft.com/devcontainers/rust:2-1-trixie",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers-extra/features/corepack:1": {},
+		"ghcr.io/devcontainers-extra/features/npm-package:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"streetsidesoftware.code-spell-checker",
+				"Gruntfuggly.todo-tree"
+			]
+		}
+	},
+	"postCreateCommand": ".devcontainer/setup.sh"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,3 +1,6 @@
+# switch to nightly rust
+rustup default nightly
+
 # install just
 cargo install just
 cargo install uniffi --features="cli" # this may have changed since the documentation attemps `cargo install uniffi-bindgen` and that no longer works

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,11 @@
+# install just
+cargo install just
+
+# dependencies
+just install-wasm-opt # not done by above
+just setup
+# just install-tools # done by above
+# just install-rust # done by above
+# just install-uniffi-deps # done by above
+
+

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,6 @@
 # install just
 cargo install just
-cargo install uniffi --features="cli" # this may have changed since the documentation is cargo install uniffi-bindgen no longer works
+cargo install uniffi --features="cli" # this may have changed since the documentation attemps `cargo install uniffi-bindgen` and that no longer works
 
 # dependencies
 just install-wasm-opt # not done by setup
@@ -8,3 +8,4 @@ just setup
 # just install-tools # done by above
 # just install-rust # done by above
 # just install-uniffi-deps # done by above
+just ensure-wasm-bindgen-cli

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,11 +1,10 @@
 # install just
 cargo install just
+cargo install uniffi --features="cli" # this may have changed since the documentation is cargo install uniffi-bindgen no longer works
 
 # dependencies
-just install-wasm-opt # not done by above
+just install-wasm-opt # not done by setup
 just setup
 # just install-tools # done by above
 # just install-rust # done by above
 # just install-uniffi-deps # done by above
-
-

--- a/justfile
+++ b/justfile
@@ -191,10 +191,10 @@ _ci-summary-failure:
 # ensure wasm-bindgen-cli is installed
 ensure-wasm-bindgen-cli:
     @if ! command -v wasm-bindgen > /dev/null || ! wasm-bindgen --version | grep -q "0.2.104"; then \
-        printf "{{info}}Installing wasm-bindgen-cli 0.2.104...{{reset}}\n" && \
-        cargo install wasm-bindgen-cli --version 0.2.104; \
+        printf "{{info}}Installing wasm-bindgen-cli 0.2.118...{{reset}}\n" && \
+        cargo install wasm-bindgen-cli --version 0.2.118; \
     else \
-        printf "{{success}}✓ wasm-bindgen-cli 0.2.104 already installed{{reset}}\n"; \
+        printf "{{success}}✓ wasm-bindgen-cli 0.2.118 already installed{{reset}}\n"; \
     fi
 
 # installs wasm-opt via cargo if missing


### PR DESCRIPTION
I've put together a devcontainer to test out a fresh build from scratch - if you've not used them before then see `https://containers.dev/` - I now develop almost exclusive in devcontainers as it simplifies development dependency hell and keeps each project isolated from others

a few observations

* the rust version appears to require a nightly build - I was getting warnings during `just test`
* I had to play around with the version of `wasm-bindgen-cli` - I'm not sure why the pinned version wasn't working
* I needed to use `cargo install uniffi --features="cli"` to install `uniffi-bindgen` as the technique in the just file wasn't working for me (`cargo install uniffi-bindgen` claims it doesn't exist - so maybe a change in that repo)
* when I run the `just fmt` a number of files get modified - has that not been applied against `main`?

the initial setup is a bit slow - but that's to be expected as it's doing a bunch of setup work - see `/.devcontain/setup.sh`